### PR TITLE
Fix incorrect usage of Eigen::Ref in SetInverseDynamicsControlGains

### DIFF
--- a/examples/planar_gripper/planar_gripper.cc
+++ b/examples/planar_gripper/planar_gripper.cc
@@ -88,8 +88,9 @@ geometry::GeometryId PlanarGripper::brick_geometry_id() const {
 }
 
 void PlanarGripper::SetInverseDynamicsControlGains(
-    const Eigen::Ref<VectorX<double>> Kp, const Eigen::Ref<VectorX<double>> Ki,
-    const Eigen::Ref<VectorX<double>> Kd) {
+    const Eigen::Ref<const VectorX<double>>& Kp,
+    const Eigen::Ref<const VectorX<double>>& Ki,
+    const Eigen::Ref<const VectorX<double>>& Kd) {
   if (Kp.size() != kNumGripperJoints || Ki.rows() != kNumGripperJoints ||
       Kd.rows() != kNumGripperJoints) {
     throw std::logic_error(

--- a/examples/planar_gripper/planar_gripper.h
+++ b/examples/planar_gripper/planar_gripper.h
@@ -300,9 +300,10 @@ class PlanarGripper : public systems::Diagram<double> {
   /**
    * Sets the gains for the internal inverse dynamics controller.
    */
-  void SetInverseDynamicsControlGains(const Eigen::Ref<VectorX<double>> Kp,
-                                      const Eigen::Ref<VectorX<double>> Ki,
-                                      const Eigen::Ref<VectorX<double>> Kd);
+  void SetInverseDynamicsControlGains(
+      const Eigen::Ref<const VectorX<double>>& Kp,
+      const Eigen::Ref<const VectorX<double>>& Ki,
+      const Eigen::Ref<const VectorX<double>>& Kd);
 
   void GetInverseDynamicsControlGains(EigenPtr<VectorX<double>> Kp,
                                       EigenPtr<VectorX<double>> Ki,


### PR DESCRIPTION
To use `Eigen::Ref` as a const reference, we should use the argument
`const Eigen::Ref<const VectorX<T>>&`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/visuomotordexterity/drake/11)
<!-- Reviewable:end -->
